### PR TITLE
Fix Typo

### DIFF
--- a/src/main/java/com/hwr/hwrzeiterfassung/controller/BookController.java
+++ b/src/main/java/com/hwr/hwrzeiterfassung/controller/BookController.java
@@ -120,7 +120,7 @@ public class BookController {
             var lastTimes = timeRepository.findAllByDayAndPause(lastDay, pause);
 
             if (!lastTimes.isEmpty())
-                return Optional.of(lastTimes.get(lastDays.size() - 1));
+                return Optional.of(lastTimes.get(lastTimes.size() - 1));
         }
         return Optional.empty();
     }


### PR DESCRIPTION
Typo in BookController, dass er nicht die letzte Time aus lastTimes zurückgibt, sondern die Rückgabe abhängig von der Size von lastDays (üblicherweise 1) machte